### PR TITLE
Check for linux and arm64 architecture

### DIFF
--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -51,6 +51,7 @@ class HeicToJpg {
      * @param string $source
      */
     public function convertImage(string $source) {
+        $this->checkLinuxOS();
         $this->processImage($source);
         $this->extractBinary();
         return $this;
@@ -92,9 +93,9 @@ class HeicToJpg {
     /**
      * Checks is used on macOS or not
      *
-     * @return void
+     * @return self
      */
-    public function checkMacOS() {
+    public function checkMacOS(): self {
         $os = strtolower(php_uname('s'));
         $arch = strtolower(php_uname('m'));
 
@@ -111,6 +112,23 @@ class HeicToJpg {
         }
 
         $this->checkDarwinExe();
+
+        return $this;
+    }
+
+    public function checkLinuxOS(): self {
+        $os = strtolower(php_uname('s'));
+        $arch = strtolower(php_uname('m'));
+
+        if (str_contains($os, 'linux')) {
+            $this->os = "linux";
+        }
+
+        if (str_contains($arch, "aarch64")){
+            $this->arch = "arm64";
+        }
+
+        $this->checkLinuxExe();
 
         return $this;
     }
@@ -180,6 +198,13 @@ class HeicToJpg {
         }
     }
 
+    private function checkLinuxExe(): void
+    {
+        if ($this->os == "linux" && $this->arch == "arm64") {
+            $this->exeName = "php-heic-to-jpg-linux-arm64";
+        }
+    }
+
     /**
      * Check os and arch properties to set executable name correctly
      *
@@ -207,10 +232,13 @@ class HeicToJpg {
             $this->exeName = "php-heic-to-jpg-darwin-amd64";
         }
     }
-    
+
     public static function convert(string $source)
     {
-        return (new self)->checkMacOS()->convertImage($source);
+        return (new self)
+            ->checkMacOS()
+            ->checkLinuxOS()
+            ->convertImage($source);
     }
 
     public static function convertOnMac(string $source, $arch = "amd64")


### PR DESCRIPTION
Hi again @MaestroError. As discussed, here's the simple PR just to implement usage for linux os with arm64 architecture.
I tried to add this to the test matrix, but since Github actions doesn't support changing the CPU architecture, I had to look at other options to test it. One of them was to use [this github action](https://github.com/uraimo/run-on-arch-action).

However, after many tries to get it to work, it seems that the the tests fail. 

I don't understand why though:
1. I tested it manually on a linux/arm64 environment, it works.
2. Instead of running the test, I tried running the full command in the workflow, and I can see the jpg has been [successfully created](https://github.com/DanielGSoftware/php-heic-to-jpg/actions/runs/4892852651/jobs/8736453238).

I'd like to give a new attempt at this later, but for now I'm wondering if it's okay to make this PR without tests.
What do you think?