### PR TITLE
Sanitize the source string

### DIFF
--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -316,7 +316,7 @@ class HeicToJpg {
         return (new self)
             ->checkOS($forceArm)
             ->setConverterLocation($converterPath)
-            ->convertImage($source);
+            ->convertImage(htmlspecialchars($source));
     }
 
     public static function convertOnMac(string $source, string $arch = "amd64", string $converterPath = "")


### PR DESCRIPTION
For security reasons we have to "sanitize" the inputted string because of manipulating it.

Since the SANITIZE_FILTER is removed at PHP >= v8 we can use htmlspecialchars