### PR TITLE
On failure: Remove temp file if one was created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 !tests/Unit/images/*
 
 vendor
+
+# JetBrains IDE config
+.idea

--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -18,13 +18,6 @@ class HeicToJpg {
     private string $jpg;
 
     /**
-     * Stores original HEIC image path
-     *
-     * @var string
-     */
-    protected string $heic;
-
-    /**
      * Executable file name from bin folder
      *
      * @var string
@@ -186,7 +179,6 @@ class HeicToJpg {
      */
     protected function processImage(string $source) {
         $source = htmlspecialchars($source);
-        $this->heic = $source;
         $newFileName = $source . "-" . uniqid(rand(), true);
         $exeName = $this->exeName;
         $command = __DIR__.'/../bin/'.$exeName.' "'.$source.'" "'.$newFileName.'" 2>&1';

--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -114,15 +114,19 @@ class HeicToJpg {
         $os = strtolower(php_uname('s'));
         $arch = strtolower(php_uname('m'));
 
-        if (str_contains($os, 'macos') || str_contains($os, 'os x') || str_contains($os, 'darwin') || str_contains($os, 'macintosh')) {
+        if (self::stringContains($os, 'macos')
+            || self::stringContains($os, 'os x')
+            || self::stringContains($os, 'darwin')
+            || self::stringContains($os, 'macintosh')
+        ) {
             $this->os = "darwin";
         }
 
-        if (str_contains($arch, "x86_64") || str_contains($arch, "amd64")) {
+        if (self::stringContains($arch, "x86_64") || self::stringContains($arch, "amd64")) {
             $this->arch = "amd64";
         }
 
-        if (str_contains($arch, "arm")) {
+        if (self::stringContains($arch, "arm")) {
             $this->arch = "arm64";
         }
 
@@ -135,11 +139,11 @@ class HeicToJpg {
         $os = strtolower(php_uname('s'));
         $arch = strtolower(php_uname('m'));
 
-        if (str_contains($os, 'linux')) {
+        if (self::stringContains($os, 'linux')) {
             $this->os = "linux";
         }
 
-        if (str_contains($arch, "aarch64") || str_contains($arch, "arm64")){
+        if (self::stringContains($arch, "aarch64") || self::stringContains($arch, "arm64")){
             $this->arch = "arm64";
         }
 
@@ -157,7 +161,7 @@ class HeicToJpg {
         $os = strtolower(php_uname('s'));
         $arch = strtolower(php_uname('m'));
 
-        if (str_contains($os, 'windows') || str_contains($os, 'win')) {
+        if (self::stringContains($os, 'windows') || self::stringContains($os, 'win')) {
             $this->os = "windows";
         }
 
@@ -366,4 +370,8 @@ class HeicToJpg {
         return false;
     }
 
+    private static function stringContains(string $haystack, string $needle): bool
+    {
+        return strpos($haystack, $needle) !== false;
+    }
 }

--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -6,49 +6,36 @@ class HeicToJpg {
 
     /**
      * Stores binary content of JPG file
-     *
      */
-    private $binary;
+    private string $binary;
 
     /**
      * Stores converted JPG file location
-     *
-     * @var string
      */
     private string $jpg;
 
     /**
      * Executable file name from bin folder
-     *
-     * @var string
      */
     protected string $exeName = "heicToJpg";
 
     /**
      * OS of server
-     *
-     * @var string
      */
     protected string $os = "linux";
 
     /**
      * Architecture of server
-     *
-     * @var string
      */
     protected string $arch = "amd64";
 
     /**
      * Force arm64
-     *
-     * @var bool
      */
     protected bool $forceArm = false;
 
     /**
      * Location of the "heif-converter-image" package's executable
-     * 
-     * @var string
      */
     protected string $libheifConverterLocation = "";
 
@@ -56,10 +43,8 @@ class HeicToJpg {
 
     /**
      * Takes full location of file as a string
-     *
-     * @param string $source
      */
-    public function convertImage(string $source) {
+    public function convertImage(string $source): self {
         $this->checkLinuxOS();
         $this->processImage($source);
         $this->extractBinary();
@@ -68,10 +53,8 @@ class HeicToJpg {
 
     /**
      * The same as convertImage but for MacOS users
-     *
-     * @param string $source
      */
-    public function convertImageMac(string $source, $arch = "amd64") {
+    public function convertImageMac(string $source, string $arch = "amd64"): self {
         $this->setDarwinExe($arch);
         $this->processImage($source);
         $this->extractBinary();
@@ -80,35 +63,27 @@ class HeicToJpg {
 
     /**
      * Saves JPG file as $path (Full location is preferable)
-     *
-     * @param string $path
-     * @return bool
      */
-    public function saveAs(string $path) {
+    public function saveAs(string $path): bool {
         file_put_contents($path, $this->binary);
         return $this->exit();
     }
 
     /**
-     * Removes temporary JPG file and returns it's content (binary)
-     *
-     * @return string
+     * Removes temporary JPG file and returns its content (binary)
      */
-    public function get() {
+    public function get(): string {
         $this->exit();
         return $this->binary;
     }
-
     
-    public function setConverterLocation(string $path) {
+    public function setConverterLocation(string $path): self {
         $this->libheifConverterLocation = $path;
         return $this;
     }
 
     /**
      * Checks is used on macOS or not
-     *
-     * @return self
      */
     public function checkMacOS(): self {
         $os = strtolower(php_uname('s'));
@@ -170,18 +145,15 @@ class HeicToJpg {
         return $this;
     }
 
-    public function checkOS($forceArm = false) {
+    public function checkOS($forceArm = false): self {
         $this->forceArm = $forceArm;
         return $this->checkWindowsOS()->checkLinuxOS()->checkMacOS();
     }
 
     /**
      * Runs heicToJpg CLI tool to convert file
-     *
-     * @param string $source
-     * @return void
      */
-    protected function processImage(string $source) {
+    protected function processImage(string $source): void {
         $source = htmlspecialchars($source);
         $newFileName = $source . "-" . uniqid(rand(), true);
         $exeName = $this->exeName;
@@ -203,7 +175,7 @@ class HeicToJpg {
         }
     }
 
-    protected function tryToConvertWithLibheif($source, $newFile) {
+    protected function tryToConvertWithLibheif(string $source, string $newFile): bool {
         // ./vendor/bin/heif-converter-linux heic input.heic output.png
         if (empty($this->libheifConverterLocation)) {
             $this->libheifConverterLocation = __DIR__.'/../bin/' . "heif-converter-" . $this->os;
@@ -228,22 +200,15 @@ class HeicToJpg {
 
     /**
      * Read the content of file
-     *
-     * @return void
      */
-    protected function extractBinary() {
-        $this->binary = file_get_contents($this->jpg);
+    protected function extractBinary(): void {
+        $this->binary = file_get_contents($this->jpg) ?: '';
     }
 
     /**
      * Returns string between $start and $end
-     *
-     * @param string $string
-     * @param string $start
-     * @param string $end
-     * @return void
      */
-    private function getStringBetween(string $string, string $start, string $end){
+    private function getStringBetween(string $string, string $start, string $end): string {
         $string = ' ' . $string;
         $ini = strpos($string, $start);
         if ($ini == 0) return '';
@@ -255,9 +220,9 @@ class HeicToJpg {
     /**
      * Removes converted JPG file
      *
-     * @return bool
+     * @throws \Exception if JPG file does not exist
      */
-    private function exit() {
+    private function exit(): bool {
         if(file_exists($this->jpg)) {
             unlink($this->jpg);
             return true;
@@ -282,10 +247,8 @@ class HeicToJpg {
 
     /**
      * Check os and arch properties to set executable name correctly
-     *
-     * @return void
      */
-    private function checkDarwinExe() {
+    private function checkDarwinExe(): void {
         if ($this->os == "darwin" && $this->arch == "amd64") {
             $this->exeName = "php-heic-to-jpg-darwin-amd64";
         }
@@ -296,11 +259,8 @@ class HeicToJpg {
 
     /**
      * Sets macOS executable by architecture
-     *
-     * @param string $arch
-     * @return void
      */
-    private function setDarwinExe(string $arch) {
+    private function setDarwinExe(string $arch): void {
         if ($arch == "arm64") {
             $this->exeName = "php-heic-to-jpg-darwin-arm64";
         } else {
@@ -308,7 +268,7 @@ class HeicToJpg {
         }
     }
 
-    public static function convert(string $source, string $converterPath = "", $forceArm = false)
+    public static function convert(string $source, string $converterPath = "", $forceArm = false): self
     {
         return (new self)
             ->checkOS($forceArm)
@@ -316,12 +276,12 @@ class HeicToJpg {
             ->convertImage($source);
     }
 
-    public static function convertOnMac(string $source, string $arch = "amd64", string $converterPath = "")
+    public static function convertOnMac(string $source, string $arch = "amd64", string $converterPath = ""): self
     {
         return (new self)->setConverterLocation($converterPath)->convertImageMac($source, $arch);
     }
 
-    public static function convertFromUrl(string $url, string $converterPath = "", $forceArm = false) {
+    public static function convertFromUrl(string $url, string $converterPath = "", $forceArm = false): self {
         // Download image
         $newFileName = "HTTP" . "-" . uniqid(rand(), true);
         file_put_contents($newFileName, file_get_contents($url));
@@ -340,9 +300,6 @@ class HeicToJpg {
 
     /**
      * Check if file is in HEIC format.
-     *
-     * @param string $path
-     * @return bool
      */
     public static function isHeic(string $path): bool
     {

--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -134,7 +134,6 @@ class HeicToJpg {
 
     public function checkWindowsOS(): self {
         $os = strtolower(php_uname('s'));
-        $arch = strtolower(php_uname('m'));
 
         if (self::stringContains($os, 'windows') || self::stringContains($os, 'win')) {
             $this->os = "windows";


### PR DESCRIPTION
The fix is just a few lines in the `HeicToJpg::processImage()` method. I verified that it resolved my issue #38. 

The issue might be specific to the linux-arm64 binary because I wasn't able to replicate the issue when I was testing locally on my mac.

Most of the commits here are general housekeeping. 

- I specified all the missing property, parameter and return types and removed the corresponding PHPDoc comments since they were redundant.
- I replaced calls to `str_contains()` with a very simple custom method since this package did not require a specific version of PHP, but `str_contains()` requires >=8.0.
- I switched to an older version of PHP and identified that the lowest possible version of this package supports is 7.4. So I added that as a requirement to the package config. I could have left the calls to `str_contains()` and set the minimum required version to 8.0, but there is no point in limiting who can use this package further than necessary. (Especially because I am still in the process of upgrading to 8.0 at work 😅)
- There are a couple other very minor changes that are self-explanatory (see commit messages)

If this PR gets merged I might contribute some other improvements if you're interested.