### PR TITLE
Replace adrium/goheif with jdeng/goheif to fix iPhone 15+ HEIC conversion panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/MaestroError/php-heic-to-jpg
 
 go 1.18
 
-require github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
+require github.com/jdeng/goheif v0.0.0-20260309214039-46ce8d592019
 
 require github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786 h1:zvgtcRb2B5gynWjm+Fc9oJZPHXwmcgyH0xCcNm6Rmo4=
-github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
+github.com/jdeng/goheif v0.0.0-20260309214039-46ce8d592019 h1:0ZoFwHuWMCMXTSZu6MpytImaIdRE6SullDaPzSw8grM=
+github.com/jdeng/goheif v0.0.0-20260309214039-46ce8d592019/go.mod h1:whEdtAJfm8ia675sbmIATUVAT/P9gnb7zHpR3hzqst0=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/adrium/goheif"
+	"github.com/jdeng/goheif"
 )
 
 // Skip Writer for exif writing


### PR DESCRIPTION
## Issue

HEIC images from iPhone 15 and later (iOS 17+) containing HDR gain map metadata (`tmap` brand in the `ftyp` box) cause the Go binary to panic with a slice bounds out-of-range error, crashing the conversion process entirely. These files are valid HEIC images that simply include Apple's newer HDR Gain Map format alongside the primary image.

Error observed in production (PII stripped):

```
goroutine 1 [running]:
github.com/adrium/goheif.(*ImageGrid).getWidth(...)
	/root/go/pkg/mod/github.com/adrium/goheif@v0.0.0-20230223132316-b6a893b884fe/heif.go:339
github.com/adrium/goheif.tileReaderAt(...)
	/root/go/pkg/mod/github.com/adrium/goheif@v0.0.0-20230223132316-b6a893b884fe/heif.go:421
runtime error: slice bounds out of range [384:256]
```

## Root Cause

The panic originates in `adrium/goheif`'s grid tile stitching code. When an HEIC file uses grid encoding (common for HDR gain map images from iPhone 15+), each tile is stored with a padded stride (YStride/CStride) that is larger than the visible tile width. The stitching logic in `adrium/goheif` does not account for this and passes the full padded buffer directly as a slice, resulting in a `slice bounds out of range` when the code tries to index `[visibleWidth:paddedStride]`.

`adrium/goheif` has been abandoned since January 2023 and this bug was never fixed.

## Fix

Switch the dependency to [`jdeng/goheif`](https://github.com/jdeng/goheif), the actively maintained fork. This specific bug was fixed in [jdeng/goheif PR #39](https://github.com/jdeng/goheif/pull/39) (merged March 9, 2026), which properly handles padded strides during grid tile stitching.

**Changes:**
- `go.mod`: replace `github.com/adrium/goheif` with `github.com/jdeng/goheif v0.0.0-20260309214039-46ce8d592019`
- `go.sum`: update checksums accordingly
- `main.go`: update import path

## Steps to Reproduce

1. Take a photo with an iPhone 15 or later running iOS 17+
2. Send the `.heic` file to the conversion binary
3. The binary panics with `slice bounds out of range`

Files from earlier iPhone models or non-HDR images are unaffected.

## References

- [jdeng/goheif PR #39 — Fix grid tile stitching with padded strides](https://github.com/jdeng/goheif/pull/39)
- [jdeng/goheif fix commit](https://github.com/jdeng/goheif/commit/46ce8d592019)
- [adrium/goheif last commit (Jan 2023 — abandoned)](https://github.com/adrium/goheif/commits/master)

---

Closes #58