### PR TITLE
Put quotes around the executable path in $command

### DIFF
--- a/src/HeicToJpg.php
+++ b/src/HeicToJpg.php
@@ -156,7 +156,7 @@ class HeicToJpg {
         $source = htmlspecialchars($source);
         $newFileName = $source . "-" . uniqid(rand(), true);
         $exeName = $this->exeName;
-        $command = __DIR__.'/../bin/'.$exeName.' "'.$source.'" "'.$newFileName.'" 2>&1';
+        $command = '"' . __DIR__ . '/../bin/' . $exeName . '" "' . $source . '" "' . $newFileName . '" 2>&1';
         exec($command, $output);
         foreach ($output as $line) {
             $parsed = $this->getStringBetween($line, '--', '--');


### PR DESCRIPTION
I'm using this on both windows and linux and my dev folder is in a path that has spaces in it which results in a RuntimeException. This commit puts quotes around the executable path in $command so that folders with spaces in windows won't break anymore.